### PR TITLE
Allow to pass customized instance of `goog.history.Html5History` to `…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changelog #
 
+## Version 1.5.0
+
+Date: 2017-04-17
+
+- Add the ability to pass customized instance of `goog.history.Html5History` to be
+  used to manage history events.
+
 ## Version 1.4.0
 
 Date: 2017-01-12

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,11 @@
 
 ## Version 1.5.0
 
-Date: 2017-04-17
+Date: 2017-04-25
 
-- Add the ability to pass customized instance of `goog.history.Html5History` to be
-  used to manage history events.
+- Add the ability to provide customized instance of `goog.history.Html5History`
+  that would be used to manage history events.
+
 
 ## Version 1.4.0
 

--- a/README.adoc
+++ b/README.adoc
@@ -79,10 +79,10 @@ the provided builtin helpers. It uses `goog.History` API under the hood:
                   :on-navigate on-navigate})
 ----
 
-Also, you can pass customized instance of `goog.history.Html5History` as value
-of `:html5history` key of second argument and `bide` would use it to manage
-history events, and/or pass `true` as value of `:html5?` key to stop using '#'
-in URLs.
+Also, you can pass factory function that returns instance of
+`goog.history.Html5History` as value of `:html5history` key of second argument
+and `bide` would use it to manage history events, and/or pass `true` as value of
+`:html5?` key to stop using '#' in URLs.
 
 Finally, you can force the navigation trigger by using the `navigate!` helper
 function:

--- a/README.adoc
+++ b/README.adoc
@@ -79,6 +79,11 @@ the provided builtin helpers. It uses `goog.History` API under the hood:
                   :on-navigate on-navigate})
 ----
 
+Also, you can pass customized instance of `goog.history.Html5History` as value
+of `:html5history` key of second argument and `bide` would use it to manage
+history events, and/or pass `true` as value of `:html5?` key to stop using '#'
+in URLs.
+
 Finally, you can force the navigation trigger by using the `navigate!` helper
 function:
 
@@ -86,6 +91,9 @@ function:
 ----
 (r/navigate! router :myapp/user-by-id {:id 10})
 ----
+
+Or if you don't want to add entry into history use `replace!` helper function
+instead.
 
 
 == How to Contribute?

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject funcool/bide "1.4.0"
+(defproject funcool/bide "1.5.0"
   :description "Simple routing for ClojureScript"
   :url "https://github.com/funcool/bide"
   :license {:name "BSD (2-Clause)"

--- a/src/bide/core.cljs
+++ b/src/bide/core.cljs
@@ -143,11 +143,12 @@
   route registered in router. Optional configuration keys are `:html5?` (`false`
   by default) and `:html5history` (new `goog.history.Html5History` instance by
   default). Passing anything that evaluates to logical false as value of
-  `:html5?` would configure history to use fragment to store token. Use
-  `:html5history` to specify custom `Html5History` instance that would be used
-  to manage history events."
+  `:html5?` would configure history to use fragment to store token. Pass factory
+  function that returns instance of `goog.history.Html5History` to
+  `:html5history` when you need to do some customizations to history instance
+  used to manage history events."
   [router {:keys [on-navigate default html5? html5history]
-           :or {html5? false html5history (Html5History.)}
+           :or {html5? false}
            :as opts}]
   (let [default (if (vector? default) default [default nil])]
     (letfn [(-on-navigate [event]
@@ -161,7 +162,8 @@
                 (if (str/blank? token)
                   (or (apply resolve router default) "/")
                   token)))]
-      (let [history (if html5?
+      (let [html5history (if (fn? html5history) (html5history) (Html5History.))
+            history (if html5?
                       (doto html5history
                         (.setPathPrefix "")
                         (.setUseFragment false)

--- a/src/bide/core.cljs
+++ b/src/bide/core.cljs
@@ -133,14 +133,21 @@
 ;; --- Browser History Binding API
 
 (defn start!
-  "Starts the bide routing handling using the goog.History
-  api as browser history event watching mechanism.
+  "Starts the bide routing handling using the `goog.history.Html5History` API as
+  browser history event watching mechanism.
 
-  If you want use the html5 history instance providing
-  a factory function that returns the Html5History object
-  instance."
-  [router {:keys [on-navigate default html5?]
-           :or {html5? false}
+  Accepts router and configuration map. Required configuration keys are
+  `:on-navigate` and `:default`. `:on-navigate` is a function that would be
+  called each time route is changed providing route id, params and query as
+  arguments. `:default` used as default route id when URL doesn't match any
+  route registered in router. Optional configuration keys are `:html5?` (`false`
+  by default) and `:html5history` (new `goog.history.Html5History` instance by
+  default). Passing anything that evaluates to logical false as value of
+  `:html5?` would configure history to use fragment to store token. Use
+  `:html5history` to specify custom `Html5History` instance that would be used
+  to manage history events."
+  [router {:keys [on-navigate default html5? html5history]
+           :or {html5? false html5history (Html5History.)}
            :as opts}]
   (let [default (if (vector? default) default [default nil])]
     (letfn [(-on-navigate [event]
@@ -155,11 +162,11 @@
                   (or (apply resolve router default) "/")
                   token)))]
       (let [history (if html5?
-                      (doto (Html5History.)
+                      (doto html5history
                         (.setPathPrefix "")
                         (.setUseFragment false)
                         (.setEnabled true))
-                      (doto (Html5History.)
+                      (doto html5history
                         (.setUseFragment true)
                         (.setEnabled true)))
             initial-token (-initial-token history)


### PR DESCRIPTION
Hi and thanks for the lib.

Today I ran into something unexpected - after each call to `navigate!` query string in browser is duplicated. When searching the cause I found same issue for other routing lib and solution [here](https://github.com/venantius/accountant/issues/19). The solution was to use custom token transformer in `goog.history.Html5History` instance. Reading comments for `start!` helper I see "If you want use the html5 history instance providing a factory function that returns the Html5History object instance", but reading code for it I can't understand the way to provide such function! So, I fork the repo and add a little code to it. Now, passing manually created instance of `Html5History` I get rid of that issue - no more duplicates :)

**Note:** I don't understand how to run tests, `lein test` says "Ran 0 tests containing 0 assertions".