### PR TITLE
Exclude resolve

### DIFF
--- a/src/bide/core.cljs
+++ b/src/bide/core.cljs
@@ -23,7 +23,7 @@
 ;; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (ns bide.core
-  (:refer-clojure :exclude [empty])
+  (:refer-clojure :exclude [empty resolve])
   (:require [bide.impl.router :as rtr]
             [bide.impl.helpers :as helpers]
             [clojure.string :as str]


### PR DESCRIPTION
This remove the WARNING with the latest CLJS version.

```
WARNING: resolve already refers to: cljs.core/resolve being replaced by: bide.core/resolve at line 121
```