### PR TITLE
Remove doubled navigation on start

### DIFF
--- a/src/bide/core.cljs
+++ b/src/bide/core.cljs
@@ -176,7 +176,6 @@
             lkey (e/listen history EventType.NAVIGATE -on-navigate)]
 
         (.replaceToken history initial-token)
-        (apply on-navigate initial-loc)
 
         (specify! router
           Object


### PR DESCRIPTION
With `(apply on-navigate initial-loc)` line the on-navigate callback is called twice when starting router. When removed, everything seems to work ok. Tested in Chrome, Safari, and Firefox on macOS.

Is there any special reason for reapplying I cannot see? It seems to me, that `.replaceToken` call on the line before removed, is enough to trigger it.