### PR TITLE
Define `-match` before using it

### DIFF
--- a/src/bide/core.cljs
+++ b/src/bide/core.cljs
@@ -151,12 +151,12 @@
            :or {html5? false}
            :as opts}]
   (let [default (if (vector? default) default [default nil])]
-    (letfn [(-on-navigate [event]
-              (let [[name params query] (-match (.-token event))]
-                (on-navigate name params query)))
-            (-match [token]
+    (letfn [(-match [token]
               (let [result (match router token)]
                 (or result default)))
+            (-on-navigate [event]
+              (let [[name params query] (-match (.-token event))]
+                (on-navigate name params query)))
             (-initial-token [history]
               (let [token (.getToken history)]
                 (if (str/blank? token)


### PR DESCRIPTION
Fix compiler warning (at least for `shadow-cljs`):

~~~~
------ WARNING #1 --------------------------------------------------------------
 File: bide/core.cljs:155:42
--------------------------------------------------------------------------------
 152 |            :as opts}]
 153 |   (let [default (if (vector? default) default [default nil])]
 154 |     (letfn [(-on-navigate [event]
 155 |               (let [[name params query] (-match (.-token event))]
------------------------------------------------^-------------------------------
 Use of undeclared Var bide.core/-match
--------------------------------------------------------------------------------
 156 |                 (on-navigate name params query)))
 157 |             (-match [token]
 158 |               (let [result (match router token)]
 159 |                 (or result default)))
--------------------------------------------------------------------------------
~~~~