### PR TITLE
Add custom TokenTransformer

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -84,6 +84,10 @@ Also, you can pass factory function that returns instance of
 and `bide` would use it to manage history events, and/or pass `true` as value of
 `:html5?` key to stop using '#' in URLs.
 
+Note that when `:html5?` is `true`, the built-in instance of `Html5History` uses
+a custom `goog.history.Html5History.TokenTransformer` to allow it to handle
+query parameters. You can construct a transformer with `token-transformer`.
+
 Finally, you can force the navigation trigger by using the `navigate!` helper
 function:
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject funcool/bide "1.6.0"
+(defproject funcool/bide "1.6.1-SNAPSHOT"
   :description "Simple routing for ClojureScript"
   :url "https://github.com/funcool/bide"
   :license {:name "BSD (2-Clause)"

--- a/src/bide/core.cljs
+++ b/src/bide/core.cljs
@@ -28,7 +28,8 @@
             [bide.impl.helpers :as helpers]
             [clojure.string :as str]
             [goog.events :as e])
-  (:import goog.history.Html5History
+  (:import bide.impl.TokenTransformer
+           goog.history.Html5History
            goog.history.EventType))
 
 ;; --- Protocols
@@ -130,6 +131,12 @@
          query (props->js query)]
      (rtr/resolve router name params query))))
 
+(defn token-transformer
+  "Construct an object that implements
+  `goog.history.Html5History.TokenTransformer` with query string support."
+  []
+  (TokenTransformer.))  
+
 ;; --- Browser History Binding API
 
 (defn start!
@@ -162,7 +169,9 @@
                 (if (str/blank? token)
                   (or (apply resolve router default) "/")
                   token)))]
-      (let [html5history (if (fn? html5history) (html5history) (Html5History.))
+      (let [html5history (if (fn? html5history)
+                           (html5history)
+                           (Html5History. nil (token-transformer)))
             history (if html5?
                       (doto html5history
                         (.setPathPrefix "")

--- a/src/bide/impl/tokentransformer.js
+++ b/src/bide/impl/tokentransformer.js
@@ -1,0 +1,61 @@
+/**
+ * TokenTransformer
+ *
+ * @author Paul Anderson <paul@andersonpaul.com>, 2018
+ * @license BSD License <https://opensource.org/licenses/BSD-2-Clause>
+ */
+
+goog.provide('bide.impl.TokenTransformer');
+
+goog.require('goog.history.Html5History');
+
+goog.scope(function() {
+  /**
+   * A goog.history.Html5History.TokenTransformer implementation that
+   * includes the query string in the token.
+   * 
+   * The implementation of token<->url transforms in
+   * `goog.history.Html5History`, when useFragment is false and no custom
+   * transformer is supplied, assumes that a token is equivalent to
+   * `window.location.pathname` minus any configured path prefix. Since
+   * bide allows constructing urls that include a query string, we want
+   * to be able to store those as tokens.
+   * 
+   * Addresses funcool/bide#15.
+   * 
+   * @constructor
+   * @implements {goog.history.Html5History.TokenTransformer}
+   */
+  bide.impl.TokenTransformer = function () {};
+
+  /**
+   * Retrieves a history token given the path prefix and
+   * `window.location` object.
+   *
+   * @param {string} pathPrefix The path prefix to use when storing token
+   *     in a path; always begin with a slash.
+   * @param {Location} location The `window.location` object.
+   *     Treat this object as read-only.
+   * @return {string} token The history token.
+   */
+  bide.impl.TokenTransformer.prototype.retrieveToken = function(pathPrefix, location) {
+    return location.pathname.substr(pathPrefix.length) + location.search;
+  };
+
+  /**
+   * Creates a URL to be pushed into HTML5 history stack when storing
+   * token without using hash fragment.
+   *
+   * @param {string} token The history token.
+   * @param {string} pathPrefix The path prefix to use when storing token
+   *     in a path; always begin with a slash.
+   * @param {Location} location The `window.location` object.
+   *     Treat this object as read-only.
+   * @return {string} url The complete URL string from path onwards
+   *     (without {@code protocol://host:port} part); must begin with a
+   *     slash.
+   */
+  bide.impl.TokenTransformer.prototype.createUrl = function(token, pathPrefix, location) {
+    return pathPrefix + token;
+  };
+});


### PR DESCRIPTION
After encountering #15 I did some debugging and it looks like this occurs because in non-fragment mode, Html5History implements a default token<->url transform that expects token to be derived from the pathname only. When receiving a new token through `navigate!` that does include query-string, it appends the existing query string, resulting in duplication. See [this line](https://github.com/google/closure-library/blob/982776432a758d4b2a2e80cea835883e02aafcf5/closure/goog/history/html5history.js#L274) in the implementation.

This adds an implementation of the interface defined for overriding that mapping, a public function to instantiate it, and a couple of sentences of documentation.

Tested this in a browser repl on my own machine, but did not write formal tests. I think it needs an integration test running in the browser (or to mock the window object?) Happy to do so, but don't know how that is commonly done in ClojureScript. Examples welcome!