### PR TITLE
Fix google closure compiler warning

### DIFF
--- a/src/bide/impl/helpers.js
+++ b/src/bide/impl/helpers.js
@@ -26,7 +26,7 @@ goog.scope(function() {
   };
 
   self.isArray = Array.isArray || function (val) {
-    return !! val && '[object Array]' == toString.call(val);
+    return !! val && '[object Array]' == Object.prototype.toString.call(val);
   };
 });
 


### PR DESCRIPTION
This fixes https://github.com/funcool/bide/issues/17. While it's true that `toString.call(x)` is not incorrect (because everything, including `window`, inherits from `Object`), this
1. removes the warning emitted by Google Closure Compiler because we're implicity referencing a global variable
2. makes compiler output less noisy for some people
3. improves consistency because the `Object.prototype`-pattern is used elsewhere as well (see line 15 of helper.js for an example)